### PR TITLE
Implement password reset flow

### DIFF
--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -6,11 +6,13 @@ import type { AppOpenAPI } from "../lib/types";
 import { BASE_PATH } from "../lib/constants";
 import index from "./index.route";
 import tasks from "./tasks/tasks.index";
+import passwordReset from "./password-reset/password-reset.index";
 
 export function registerRoutes(app: AppOpenAPI) {
   return app
     .route("/", index)
-    .route("/", tasks);
+    .route("/", tasks)
+    .route("/", passwordReset);
 }
 
 // stand alone router type used for api client

--- a/apps/api/src/routes/password-reset/password-reset.handlers.ts
+++ b/apps/api/src/routes/password-reset/password-reset.handlers.ts
@@ -1,0 +1,82 @@
+import { eq, gt } from "drizzle-orm";
+import { v4 as uuidv4 } from "uuid";
+import * as HttpStatusCodes from "stoker/http-status-codes";
+
+import type { AppRouteHandler } from "@/api/lib/types";
+import { accounts, users, verifications } from "@/api/db/auth.schema";
+
+import type { ConfirmResetRoute, RequestResetRoute } from "./password-reset.routes";
+
+export const requestReset: AppRouteHandler<RequestResetRoute> = async (c) => {
+  const db = c.get("db");
+  const { email } = c.req.valid("json");
+
+  const user = await db.query.users.findFirst({
+    where(fields, operators) {
+      return operators.eq(fields.email, email);
+    },
+  });
+
+  if (user) {
+    const token = uuidv4();
+    await db.insert(verifications).values({
+      id: uuidv4(),
+      identifier: email,
+      value: token,
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    });
+    // In production an email would be sent here
+    return c.json({ message: "Password reset token created", token }, HttpStatusCodes.OK);
+  }
+
+  return c.json({ message: "If the email exists, you'll receive instructions." }, HttpStatusCodes.OK);
+};
+
+export const confirmReset: AppRouteHandler<ConfirmResetRoute> = async (c) => {
+  const db = c.get("db");
+  const auth = c.get("auth");
+  const { token, password } = c.req.valid("json");
+
+  const verification = await db.query.verifications.findFirst({
+    where(fields, operators) {
+      return operators.and(
+        operators.eq(fields.value, token),
+        operators.gt(fields.expiresAt, new Date()),
+      );
+    },
+  });
+
+  if (!verification) {
+    return c.json({ message: "Invalid or expired token" }, HttpStatusCodes.UNAUTHORIZED);
+  }
+
+  const user = await db.query.users.findFirst({
+    where(fields, operators) {
+      return operators.eq(fields.email, verification.identifier);
+    },
+  });
+
+  if (!user) {
+    return c.json({ message: "Invalid token" }, HttpStatusCodes.UNAUTHORIZED);
+  }
+
+  await db.update(accounts)
+    .set({ password })
+    .where(eq(accounts.userId, user.id));
+
+  await db.delete(verifications)
+    .where(eq(verifications.id, verification.id));
+
+  // Attempt automatic sign-in using better-auth
+  try {
+    const res = await auth.api.signIn.email({
+      email: user.email,
+      password,
+      rememberMe: true,
+    }, { headers: c.req.raw.headers });
+    return res;
+  }
+  catch {
+    return c.json({ message: "Password reset" }, HttpStatusCodes.OK);
+  }
+};

--- a/apps/api/src/routes/password-reset/password-reset.index.ts
+++ b/apps/api/src/routes/password-reset/password-reset.index.ts
@@ -1,0 +1,10 @@
+import createRouter from "@/api/lib/create-router";
+
+import * as handlers from "./password-reset.handlers";
+import * as routes from "./password-reset.routes";
+
+const router = createRouter()
+  .openapi(routes.requestReset, handlers.requestReset)
+  .openapi(routes.confirmReset, handlers.confirmReset);
+
+export default router;

--- a/apps/api/src/routes/password-reset/password-reset.routes.ts
+++ b/apps/api/src/routes/password-reset/password-reset.routes.ts
@@ -1,0 +1,62 @@
+import { createRoute, z } from "@hono/zod-openapi";
+import * as HttpStatusCodes from "stoker/http-status-codes";
+import { jsonContent, jsonContentRequired } from "stoker/openapi/helpers";
+import { createErrorSchema } from "stoker/openapi/schemas";
+
+const tags = ["Password Reset"];
+
+export const requestReset = createRoute({
+  path: "/password-reset",
+  method: "post",
+  request: {
+    body: jsonContentRequired(
+      z.object({ email: z.string().email() }),
+      "Email address"
+    ),
+  },
+  tags,
+  responses: {
+    [HttpStatusCodes.OK]: jsonContent(
+      z.object({ message: z.string(), token: z.string().optional() }),
+      "Token for development"
+    ),
+    [HttpStatusCodes.UNPROCESSABLE_ENTITY]: jsonContent(
+      createErrorSchema(z.object({ email: z.string().email() })),
+      "Validation error"
+    ),
+  },
+});
+
+export const confirmReset = createRoute({
+  path: "/password-reset/confirm",
+  method: "post",
+  request: {
+    body: jsonContentRequired(
+      z.object({
+        token: z.string(),
+        password: z.string().min(8),
+      }),
+      "Token and new password"
+    ),
+  },
+  tags,
+  responses: {
+    [HttpStatusCodes.OK]: jsonContent(
+      z.object({ message: z.string() }),
+      "Password changed"
+    ),
+    [HttpStatusCodes.UNAUTHORIZED]: jsonContent(
+      z.object({ message: z.string() }),
+      "Invalid token"
+    ),
+    [HttpStatusCodes.UNPROCESSABLE_ENTITY]: jsonContent(
+      createErrorSchema(
+        z.object({ token: z.string(), password: z.string().min(8) })
+      ),
+      "Validation error"
+    ),
+  },
+});
+
+export type RequestResetRoute = typeof requestReset;
+export type ConfirmResetRoute = typeof confirmReset;

--- a/apps/api/src/routes/password-reset/password-reset.test.ts
+++ b/apps/api/src/routes/password-reset/password-reset.test.ts
@@ -1,0 +1,26 @@
+import {
+  applyD1Migrations,
+  env,
+} from "cloudflare:test";
+import { testClient } from "hono/testing";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import createApp from "@/api/lib/create-app";
+
+import router from "./password-reset.index";
+
+const client = testClient(createApp().route("/", router), env);
+
+describe("password reset routes", async () => {
+  beforeAll(async () => {
+    // @ts-expect-error test
+    await applyD1Migrations(env.DB, env.TEST_MIGRATIONS);
+  });
+
+  it("post /password-reset returns success", async () => {
+    const response = await client.api["password-reset"].$post({
+      json: { email: "test@example.com" },
+    });
+    expect(response.status).toBe(200);
+  });
+});

--- a/apps/web/src/route-tree.gen.ts
+++ b/apps/web/src/route-tree.gen.ts
@@ -17,6 +17,7 @@ import { Route as AuthenticatedProfileImport } from './routes/_authenticated/pro
 import { Route as AuthSignupImport } from './routes/_auth/signup'
 import { Route as AuthSigninImport } from './routes/_auth/signin'
 import { Route as AuthForgotPasswordImport } from './routes/_auth/forgot-password'
+import { Route as AuthResetPasswordImport } from './routes/_auth/reset-password'
 import { Route as AdminAdminDashboardIndexImport } from './routes/_admin/admin-dashboard/index'
 import { Route as TaskEditIdImport } from './routes/task/edit.$id'
 
@@ -68,6 +69,12 @@ const AuthForgotPasswordRoute = AuthForgotPasswordImport.update({
   getParentRoute: () => rootRoute,
 } as any)
 
+const AuthResetPasswordRoute = AuthResetPasswordImport.update({
+  id: '/_auth/reset-password',
+  path: '/reset-password',
+  getParentRoute: () => rootRoute,
+} as any)
+
 const AdminAdminDashboardIndexRoute = AdminAdminDashboardIndexImport.update({
   id: '/admin-dashboard/',
   path: '/admin-dashboard/',
@@ -110,6 +117,13 @@ declare module '@tanstack/react-router' {
       path: '/forgot-password'
       fullPath: '/forgot-password'
       preLoaderRoute: typeof AuthForgotPasswordImport
+      parentRoute: typeof rootRoute
+    }
+    '/_auth/reset-password': {
+      id: '/_auth/reset-password'
+      path: '/reset-password'
+      fullPath: '/reset-password'
+      preLoaderRoute: typeof AuthResetPasswordImport
       parentRoute: typeof rootRoute
     }
     '/_auth/signin': {
@@ -186,6 +200,7 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '': typeof AuthenticatedRouteRouteWithChildren
   '/forgot-password': typeof AuthForgotPasswordRoute
+  '/reset-password': typeof AuthResetPasswordRoute
   '/signin': typeof AuthSigninRoute
   '/signup': typeof AuthSignupRoute
   '/profile': typeof AuthenticatedProfileRoute
@@ -198,6 +213,7 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '': typeof AuthenticatedRouteRouteWithChildren
   '/forgot-password': typeof AuthForgotPasswordRoute
+  '/reset-password': typeof AuthResetPasswordRoute
   '/signin': typeof AuthSigninRoute
   '/signup': typeof AuthSignupRoute
   '/profile': typeof AuthenticatedProfileRoute
@@ -212,6 +228,7 @@ export interface FileRoutesById {
   '/_admin': typeof AdminRouteRouteWithChildren
   '/_authenticated': typeof AuthenticatedRouteRouteWithChildren
   '/_auth/forgot-password': typeof AuthForgotPasswordRoute
+  '/_auth/reset-password': typeof AuthResetPasswordRoute
   '/_auth/signin': typeof AuthSigninRoute
   '/_auth/signup': typeof AuthSignupRoute
   '/_authenticated/profile': typeof AuthenticatedProfileRoute
@@ -226,6 +243,7 @@ export interface FileRouteTypes {
     | '/'
     | ''
     | '/forgot-password'
+    | '/reset-password'
     | '/signin'
     | '/signup'
     | '/profile'
@@ -237,6 +255,7 @@ export interface FileRouteTypes {
     | '/'
     | ''
     | '/forgot-password'
+    | '/reset-password'
     | '/signin'
     | '/signup'
     | '/profile'
@@ -249,6 +268,7 @@ export interface FileRouteTypes {
     | '/_admin'
     | '/_authenticated'
     | '/_auth/forgot-password'
+    | '/_auth/reset-password'
     | '/_auth/signin'
     | '/_auth/signup'
     | '/_authenticated/profile'
@@ -263,6 +283,7 @@ export interface RootRouteChildren {
   AdminRouteRoute: typeof AdminRouteRouteWithChildren
   AuthenticatedRouteRoute: typeof AuthenticatedRouteRouteWithChildren
   AuthForgotPasswordRoute: typeof AuthForgotPasswordRoute
+  AuthResetPasswordRoute: typeof AuthResetPasswordRoute
   AuthSigninRoute: typeof AuthSigninRoute
   AuthSignupRoute: typeof AuthSignupRoute
   TaskIdRoute: typeof TaskIdRoute
@@ -274,6 +295,7 @@ const rootRouteChildren: RootRouteChildren = {
   AdminRouteRoute: AdminRouteRouteWithChildren,
   AuthenticatedRouteRoute: AuthenticatedRouteRouteWithChildren,
   AuthForgotPasswordRoute: AuthForgotPasswordRoute,
+  AuthResetPasswordRoute: AuthResetPasswordRoute,
   AuthSigninRoute: AuthSigninRoute,
   AuthSignupRoute: AuthSignupRoute,
   TaskIdRoute: TaskIdRoute,
@@ -296,6 +318,7 @@ export const routeTree = rootRoute
         "/_auth/forgot-password",
         "/_auth/signin",
         "/_auth/signup",
+        "/_auth/reset-password",
         "/task/$id",
         "/task/edit/$id"
       ]
@@ -323,6 +346,9 @@ export const routeTree = rootRoute
     },
     "/_auth/signup": {
       "filePath": "_auth/signup.tsx"
+    },
+    "/_auth/reset-password": {
+      "filePath": "_auth/reset-password.tsx"
     },
     "/_authenticated/profile": {
       "filePath": "_authenticated/profile.tsx",

--- a/apps/web/src/routes/_auth/forgot-password.tsx
+++ b/apps/web/src/routes/_auth/forgot-password.tsx
@@ -1,21 +1,43 @@
 import { createFileRoute } from "@tanstack/react-router";
 
-import { AuthLayout, Button, Field, Heading, Input, Label, Strong, Text, TextLink } from "@/web/components";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm, type SubmitHandler } from "react-hook-form";
+import { z } from "zod";
+
+import { AuthLayout, Button, Field, Heading, Input, Label, Strong, Text, TextLink, ErrorMessage } from "@/web/components";
 
 export const Route = createFileRoute("/_auth/forgot-password")({
   component: ForgotPassword,
 });
 
+const schema = z.object({
+  email: z.string().email(),
+});
+
 function ForgotPassword() {
+  const { register, handleSubmit, formState: { errors } } = useForm<z.infer<typeof schema>>({
+    resolver: zodResolver(schema),
+  });
+
+  const onSubmit: SubmitHandler<z.infer<typeof schema>> = async (data) => {
+    await fetch("/api/password-reset", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify(data),
+    });
+    alert("Check your email for reset instructions");
+  };
+
   return (
     <AuthLayout>
-      <form action="" method="POST" className="grid w-full max-w-sm grid-cols-1 gap-8">
-        {/* <Logo className="h-6 text-zinc-950 dark:text-white forced-colors:text-[CanvasText]" /> */}
+      <form onSubmit={handleSubmit(onSubmit)} className="grid w-full max-w-sm grid-cols-1 gap-8">
         <Heading>Reset your password</Heading>
         <Text>Enter your email and we’ll send you a link to reset your password.</Text>
         <Field>
           <Label>Email</Label>
-          <Input type="email" name="email" />
+          <Input {...register("email")} type="email" />
+          {errors.email && <ErrorMessage>{errors.email.message}</ErrorMessage>}
         </Field>
         <Button type="submit" className="w-full">
           Reset password

--- a/apps/web/src/routes/_auth/reset-password.tsx
+++ b/apps/web/src/routes/_auth/reset-password.tsx
@@ -1,0 +1,62 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { useForm, type SubmitHandler } from "react-hook-form";
+import { z } from "zod";
+
+import { AuthLayout, Button, ErrorMessage, Field, Heading, Input, Label } from "@/web/components";
+
+export const Route = createFileRoute("/_auth/reset-password")({
+  component: ResetPassword,
+  validateSearch: z.object({ token: z.string() }),
+});
+
+const schema = z.object({
+  password: z.string().min(8),
+  confirmPassword: z.string().min(8),
+}).refine(d => d.password === d.confirmPassword, {
+  message: "Passwords don't match",
+  path: ["confirmPassword"],
+});
+
+function ResetPassword() {
+  const { token } = Route.useSearch();
+  const navigate = useNavigate();
+
+  const { register, handleSubmit, formState: { errors } } = useForm<z.infer<typeof schema>>({
+    resolver: zodResolver(schema),
+  });
+
+  const onSubmit: SubmitHandler<z.infer<typeof schema>> = async (data) => {
+    const res = await fetch("/api/password-reset/confirm", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify({ token, password: data.password }),
+    });
+    if (res.ok) {
+      navigate({ to: "/" });
+    }
+    else {
+      alert("Password reset failed");
+    }
+  };
+
+  return (
+    <AuthLayout>
+      <form onSubmit={handleSubmit(onSubmit)} className="grid w-full max-w-sm grid-cols-1 gap-8">
+        <Heading>Set a new password</Heading>
+        <Field>
+          <Label>New password</Label>
+          <Input {...register("password")} type="password" />
+          {errors.password && <ErrorMessage>{errors.password.message}</ErrorMessage>}
+        </Field>
+        <Field>
+          <Label>Confirm password</Label>
+          <Input {...register("confirmPassword")} type="password" />
+          {errors.confirmPassword && <ErrorMessage>{errors.confirmPassword.message}</ErrorMessage>}
+        </Field>
+        <Button type="submit" className="w-full">Change password</Button>
+      </form>
+    </AuthLayout>
+  );
+}


### PR DESCRIPTION
## Summary
- add password reset API endpoints
- wire password reset router into API
- improve Forgot Password page to call new endpoint
- add Reset Password page
- update route tree for new route

## Testing
- `pnpm test` *(fails: unable to download pnpm)*