### PR TITLE
Add error alerts to signin/signup pages

### DIFF
--- a/apps/web/src/routes/_auth/signin.tsx
+++ b/apps/web/src/routes/_auth/signin.tsx
@@ -2,10 +2,11 @@ import type { SubmitHandler } from "react-hook-form";
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
-import { AuthLayout, Button, Checkbox, CheckboxField, ErrorMessage, Field, Heading, Input, Label, Logo, Strong, Text, TextLink } from "@/web/components";
+import { Alert, AuthLayout, Button, Checkbox, CheckboxField, ErrorMessage, Field, Heading, Input, Label, Logo, Strong, Text, TextLink } from "@/web/components";
 import { signIn } from "@/web/lib/auth-client";
 
 export const Route = createFileRoute("/_auth/signin")({
@@ -21,6 +22,7 @@ const schema = z.object({
 });
 
 function SignIn() {
+  const [hasError, setHasError] = useState(false);
   const { redirect } = Route.useSearch();
   const navigate = useNavigate();
 
@@ -37,6 +39,7 @@ function SignIn() {
   });
 
   const onSubmit: SubmitHandler<z.infer<typeof schema>> = async (data) => {
+    setHasError(false);
     const res = await signIn.email({
       email: data.email,
       password: data.password,
@@ -44,7 +47,7 @@ function SignIn() {
     });
 
     if (res.error) {
-      alert(res.error.message || "Authentication failed");
+      setHasError(true);
     }
     else {
       navigate({ to: redirect ?? "/" });
@@ -55,6 +58,9 @@ function SignIn() {
       <form onSubmit={handleSubmit(onSubmit)} className="grid w-full max-w-sm grid-cols-1 gap-8">
         <Logo className="h-16 text-zinc-950 dark:text-white forced-colors:text-[CanvasText]" />
         <Heading>Sign in to your account</Heading>
+        {hasError && (
+          <Alert variant="error" title="An error has occurred" description="Authentication failed. Please try again." />
+        )}
         <Field>
           <Label>Email</Label>
           <Input {...register("email")} type="email" required autoComplete="email" />

--- a/apps/web/src/routes/_auth/signup.tsx
+++ b/apps/web/src/routes/_auth/signup.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { useState } from "react";
 
-import { Logo, AuthLayout, Button, Checkbox, CheckboxField, Field, Heading, Input, Label, Select, Strong, Text, TextLink, ErrorMessage } from "@/web/components";
+import { Alert, Logo, AuthLayout, Button, Checkbox, CheckboxField, Field, Heading, Input, Label, Select, Strong, Text, TextLink, ErrorMessage } from "@/web/components";
 import { signUp } from "@/web/lib/auth-client";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { SubmitHandler, useForm } from "react-hook-form";
@@ -24,6 +25,7 @@ const schema = z.object({
 });
 
 function SignUp() {
+  const [hasError, setHasError] = useState(false);
   const { redirect } = Route.useSearch();
   const navigate = useNavigate();
 
@@ -42,6 +44,7 @@ function SignUp() {
   });
 
   const onSubmit: SubmitHandler<z.infer<typeof schema>> = async (data) => {
+    setHasError(false);
     const res = await signUp.email({
       email: data.email,
       password: data.password,
@@ -49,7 +52,7 @@ function SignUp() {
     });
 
     if (res.error) {
-      alert(res.error.message || "Authentication failed");
+      setHasError(true);
     }
     else {
       navigate({ to: redirect ?? "/" });
@@ -61,6 +64,9 @@ function SignUp() {
       <form onSubmit={handleSubmit(onSubmit)} className="grid w-full max-w-sm grid-cols-1 gap-8">
         <Logo className="h-16 text-zinc-950 dark:text-white forced-colors:text-[CanvasText]" />
         <Heading>Create your account</Heading>
+        {hasError && (
+          <Alert variant="error" title="An error has occurred" description="Authentication failed. Please try again." />
+        )}
         <Field>
           <Label>Email</Label>
           <Input {...register("email")} type="email" required autoComplete="email" />


### PR DESCRIPTION
## Summary
- show inline error alerts on signin page
- show inline error alerts on signup page

## Testing
- `pnpm lint` *(fails: connect EHOSTUNREACH)*
- `pnpm typecheck` *(fails: connect EHOSTUNREACH)*
- `pnpm test` *(fails: connect EHOSTUNREACH)*